### PR TITLE
Fix "findDOMNode is deprecated in StrictMode"

### DIFF
--- a/src/components/SideNav/SideNav.styles.ts
+++ b/src/components/SideNav/SideNav.styles.ts
@@ -1,4 +1,7 @@
-import { makeStyles, createMuiTheme } from "@material-ui/core/styles";
+import {
+  makeStyles,
+  unstable_createMuiStrictModeTheme as createMuiTheme,
+} from "@material-ui/core/styles";
 
 export const useStyles = makeStyles(theme => ({
   root: {


### PR DESCRIPTION
# Fix "findDOMNode is deprecated in StrictMode"

## What are you adding?
changed to import unstable_createMuiStrictModeTheme as createMuiTheme

## Breaking changes?
no

## Related PR
no
