### PR TITLE
add modal helper to control modal actions

### DIFF
--- a/src/features/settings/screens/UsersScreen/UsersScreen.tsx
+++ b/src/features/settings/screens/UsersScreen/UsersScreen.tsx
@@ -7,7 +7,7 @@ import { useMount } from "react-use";
 import Button from "@app/components/atoms/Button/Button";
 import ScreenTitleView from "@app/components/molecules/ScreenTitleView/ScreenTitleView";
 import TableView from "@app/components/molecules/TableView/TableView";
-import { ItemModalEnum } from "@app/constants/route.constants";
+import * as modalAction from "@app/helpers/modal.helper";
 import useSearchParams from "@app/hooks/useSearchParams";
 
 import styles from "./UsersScreen.module.scss";
@@ -74,24 +74,15 @@ const UsersScreen = () => {
   };
 
   const handleEdit = (user: UserDef) => {
-    updateSearchParams({
-      action: ItemModalEnum.EDIT,
-      actionId: user.id.toString(),
-    });
+    updateSearchParams(modalAction.edit(user.id.toString()));
   };
 
   const handleAdd = () => {
-    updateSearchParams({
-      action: ItemModalEnum.ADD,
-      actionId: undefined,
-    });
+    updateSearchParams(modalAction.add());
   };
 
   const handleCloseModal = () => {
-    updateSearchParams({
-      actionId: undefined,
-      action: undefined,
-    });
+    updateSearchParams(modalAction.close());
   };
 
   return (

--- a/src/helpers/modal.helper.ts
+++ b/src/helpers/modal.helper.ts
@@ -1,0 +1,21 @@
+import { ItemModalEnum } from "@app/constants/route.constants";
+
+export const add = () => {
+  return {
+    action: ItemModalEnum.ADD,
+    actionId: undefined,
+  };
+};
+export const edit = (id: string) => {
+  return {
+    action: ItemModalEnum.EDIT,
+    actionId: id,
+  };
+};
+
+export const close = () => {
+  return {
+    actionId: undefined,
+    action: undefined,
+  };
+};


### PR DESCRIPTION
# Ant design add modal helper to control modal actions

## What are you adding?
- Added `modal.helper.ts` to make reusable logic for different modal actions like add edit and close
- Open/close modal of UsersScreen using modal action
## Breaking changes?
No

## Related PR
No
