### PR TITLE
Feat/nested route permissions

### DIFF
--- a/src/features/localization/config/localization.config.ts
+++ b/src/features/localization/config/localization.config.ts
@@ -29,6 +29,9 @@ i18next.use(initReactI18next).init({
         default: {
           notFoundTitle: "404 - Not found",
           notFoundText: "The page you were looking for was not found.",
+          restrictAccessTitle: "Access denied",
+          restrictAccessText:
+            "Sorry! You don't have necessary permission to access this page!",
           columnAction: "Action",
           deleteTitle: "Delete",
           confirmDeleteTitle: "Are you sure to delete this?",

--- a/src/features/settings/routes/SettingsRoutes.tsx
+++ b/src/features/settings/routes/SettingsRoutes.tsx
@@ -1,24 +1,12 @@
-import { Switch, Route } from "react-router-dom";
-
 import { flatten } from "@app/helpers/route.helper";
+import NestedRouteWrapper from "@app/routes/NestedRouteWrapper";
 
 import { SETTINGS_ROUTES } from "./settings.routes";
 
 const SettingsRoutes = () => {
   const routesWithComponents = flatten(SETTINGS_ROUTES);
 
-  return (
-    <Switch>
-      {routesWithComponents.map(route => (
-        <Route
-          exact
-          key={route.id}
-          path={route.path}
-          component={route.component}
-        />
-      ))}
-    </Switch>
-  );
+  return <NestedRouteWrapper routesWithComponents={routesWithComponents} />;
 };
 
 export default SettingsRoutes;

--- a/src/routes/NestedRouteWrapper.tsx
+++ b/src/routes/NestedRouteWrapper.tsx
@@ -1,0 +1,40 @@
+import { Switch, Route } from "react-router-dom";
+
+import { Permission } from "@app/features/permissions/permissions";
+import RestrictAccess from "@app/routes/components/RestrictAccess/RestrictAccess";
+import { RouteComponentDef, RouteItemDef } from "@app/types/route.types";
+
+interface NestedRouteWrapperProps {
+  routesWithComponents: RouteItemDef[];
+}
+
+const NestedRouteWrapper = ({
+  routesWithComponents,
+}: NestedRouteWrapperProps) => {
+  return (
+    <Switch>
+      {routesWithComponents.map(route => (
+        <Route
+          exact
+          key={route.id}
+          path={route.path}
+          render={routeProps => {
+            const Component = route.component as RouteComponentDef;
+            return (
+              (route.permissions && (
+                <Permission
+                  fallback={<RestrictAccess />}
+                  requiredPermissions={route.permissions}
+                >
+                  <Component {...routeProps} />
+                </Permission>
+              )) || <Component {...routeProps} />
+            );
+          }}
+        />
+      ))}
+    </Switch>
+  );
+};
+
+export default NestedRouteWrapper;

--- a/src/routes/components/RestrictAccess/RestrictAccess.tsx
+++ b/src/routes/components/RestrictAccess/RestrictAccess.tsx
@@ -1,0 +1,21 @@
+import { Button, Result } from "antd";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+
+const RestrictAccess = () => {
+  const { t } = useTranslation();
+  return (
+    <Result
+      status="403"
+      title={t("default.restrictAccessTitle")}
+      subTitle={t("default.restrictAccessText")}
+      extra={
+        <Link to="/">
+          <Button type="primary">{t("default.notFoundBackHomeButton")}</Button>
+        </Link>
+      }
+    />
+  );
+};
+
+export default RestrictAccess;


### PR DESCRIPTION
# Reusable wrapper  for nested routes

## What are you adding?
- added default restrict access page
- added  `NestedRouteWrapper` for rendering nested routes with permissions
## Breaking changes?


## Related PR

