### PR TITLE
Feature/page filter updates

### DIFF
--- a/src/components/atoms/DebouncedInput/DebouncedInput.tsx
+++ b/src/components/atoms/DebouncedInput/DebouncedInput.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from "react";
+
 import { Input, InputProps } from "antd";
 import _debounce from "lodash/debounce";
 
@@ -16,6 +18,15 @@ const DebouncedInput = ({
   wait = 500,
   ...props
 }: DebouncedInputProps) => {
+  const inputRef = useRef<Input>(null);
+
+  useEffect(() => {
+    // This will allow parent to update value
+    if (inputRef.current) {
+      inputRef.current.setValue(value as string);
+    }
+  }, [value]);
+
   // Debounce the changes to the value
   const debouncedOnChange = _debounce(
     (
@@ -39,6 +50,7 @@ const DebouncedInput = ({
     <Input
       defaultValue={value}
       onChange={persistedOnChange(onChange)}
+      ref={inputRef}
       {...props}
     />
   );

--- a/src/components/molecules/PageFilter/PageFilter.tsx
+++ b/src/components/molecules/PageFilter/PageFilter.tsx
@@ -88,12 +88,6 @@ const PageFilter = <T extends {}>({
     [parseBoolean, parseDates, parseNumbers, search]
   );
 
-  const data = useCallback(
-    () => (parseBoolean || parseDates || parseNumbers ? parseSearch() : search),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
-
   // Every time the search is updated
   // then we reset the fields and parse in the search values
   // this will update the form values when going back
@@ -134,7 +128,6 @@ const PageFilter = <T extends {}>({
 
   return (
     <Form
-      initialValues={data}
       {...rest}
       form={form}
       onValuesChange={!showSubmitButton ? handleChange : undefined}

--- a/src/components/molecules/PageFilter/PageFilter.tsx
+++ b/src/components/molecules/PageFilter/PageFilter.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import React, { memo, useCallback, useEffect, useState } from "react";
+import React, { memo, useCallback, useEffect } from "react";
 
 import { Form, FormProps, Row, Col, Button } from "antd";
 import _mapValues from "lodash/mapValues";
@@ -88,13 +88,14 @@ const PageFilter = <T extends {}>({
     [parseBoolean, parseDates, parseNumbers, search]
   );
 
-  const [data, setData] = useState(
-    parseBoolean || parseDates || parseNumbers ? parseSearch() : search
+  const data = useCallback(
+    () => (parseBoolean || parseDates || parseNumbers ? parseSearch() : search),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
   );
 
   useEffect(() => {
     if (parseBoolean || parseDates || parseNumbers) {
-      setData(parseSearch());
     }
   }, [parseBoolean, parseDates, parseNumbers, parseSearch, search]);
 

--- a/src/components/molecules/PageFilter/PageFilter.tsx
+++ b/src/components/molecules/PageFilter/PageFilter.tsx
@@ -94,10 +94,22 @@ const PageFilter = <T extends {}>({
     []
   );
 
+  // Every time the search is updated
+  // then we reset the fields and parse in the search values
+  // this will update the form values when going back
+  // and forth in the navigation history
   useEffect(() => {
+    let allFields: Record<string, unknown> = _mapValues(
+      form.getFieldsValue(),
+      () => undefined
+    );
     if (parseBoolean || parseDates || parseNumbers) {
+      allFields = { ...allFields, ...parseSearch() };
+    } else {
+      allFields = { ...allFields, ...search };
     }
-  }, [parseBoolean, parseDates, parseNumbers, parseSearch, search]);
+    form.setFieldsValue(allFields);
+  }, [form, parseBoolean, parseDates, parseNumbers, parseSearch, search]);
 
   // Submit filters, update search params.
   const handleSubmit = (values: Record<string, unknown>) => {

--- a/src/components/molecules/PageFilter/helpers/page-filter.helpers.ts
+++ b/src/components/molecules/PageFilter/helpers/page-filter.helpers.ts
@@ -17,7 +17,6 @@ const isStringNumber = (value: unknown) =>
 
 export const parseFilters = <T>({
   filters,
-  parseBoolean,
   parseDates,
   parseNumbers,
 }: ParseFilterParams<T>) => {
@@ -28,14 +27,6 @@ export const parseFilters = <T>({
 
     if (typeof value === "string") {
       if (
-        parseBoolean &&
-        (isArrayIncludes<T>(parseBoolean, key) ||
-          value === "false" ||
-          value === "true")
-      ) {
-        parsedFilters[key] = JSON.parse(value);
-        parsed = true;
-      } else if (
         parseNumbers &&
         isStringNumber(value) &&
         (isArrayIncludes<T>(parseNumbers, key) || !Array.isArray(parseNumbers))

--- a/src/components/molecules/PageFilter/page-filter.md
+++ b/src/components/molecules/PageFilter/page-filter.md
@@ -46,17 +46,16 @@ You will now have code completion, and TypeScript won't flag it is a non-exist p
 
 ## Parsing field types
 
-By default when retrieving search params from the URL, they are all returned as a `string`. If you have fields that have values other than strings, we have built in the functionality to parse `booleans`, `dates`, and `numbers`. If you do not use these properties, then your filter will fail upon page reload, if the URL contains predefined filter params, as the strings will not match up to your field's specific data type.
+By default when retrieving search params from the URL, they are all returned as a `string` or `boolean`. If you have fields that have values other than strings and booleans, then we have built in the functionality to parse `dates` and `numbers`. If you do not use these properties, then your filter will fail upon page reload, if the URL contains predefined filter params, as the value will not match up to your field's specific data type.
 
 | Property       | Description                                                                                                                                                                                                                                                                   | Type                         | Default |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------- |
-| `parseBoolean` | Runs through the query string and parses strings with boolean values. You can pass it an array of the specific keys that should be passed, or a boolean if all strings with boolean values should be parsed. **Use when you have checkboxes, radio buttons, or switches.**    | `boolean` \| Array\<keyof T> | `true`  |
 | `parseDates`   | Runs through the query string and parses strings with date values. You can pass it an array of the specific keys that should be passed, or a boolean if all strings and arrays with date values should be parsed. **Use this when using date pickers.**                       | `boolean` \| Array\<keyof T> | -       |
 | `parseNumbers` | Runs through the query string and parses strings with numbers. You can pass it an array of the specific keys that should be passed, or a boolean if all strings and arrays with number values should be parsed. **Use when you have fields that contain numbers for values.** | `boolean` \| Array\<keyof T> | -       |
 
 ### Specifying fields to parse
 
-As noted for all the parameters, you can either pass in a `boolean`, or an `array`. Passing in `array` of `strings` allows you to specify exactly which fields / parameters you want parsed, and as what data type. It is also recommended to pass a type containing the properties to the PageFilter. Let's take a look at an example.
+As noted for all the parameters, you can either pass in a `boolean` or an `array`. Passing in `array` of `strings` allows you to specify exactly which fields / parameters you want parsed, and as what data type. It is also recommended to pass a type containing the properties to the PageFilter. Let's take a look at an example.
 
 ```tsx
 import { Select } from "antd";

--- a/src/components/molecules/PageFilter/types/page-filter.types.ts
+++ b/src/components/molecules/PageFilter/types/page-filter.types.ts
@@ -2,16 +2,6 @@ type ParseDef<T> = boolean | Array<keyof T>;
 
 export interface ParseFiltersProps<T> {
   /**
-   * Runs through the query string and parses string with boolean
-   * values. If a boolean is passed, all strings with boolean values will
-   * be parsed. If you want to specify which key / property to parse,
-   * you can pass it an array of strings for keys, but you will also
-   * need to pass a type containing the properties to the PageFilter.
-   *
-   * **Use when you have checkboxes, radio buttons, or switches.**
-   */
-  parseBoolean?: ParseDef<T>;
-  /**
    * Runs through the query string and parses strings with date values.
    * If a boolean is passed, all strings and arrays with date values will be parsed.
    * If you want to specify which key / property to parse, you can pass

--- a/src/hooks/useSearchParams.ts
+++ b/src/hooks/useSearchParams.ts
@@ -2,12 +2,22 @@
 import { useCallback, useEffect, useState } from "react";
 
 import _toInteger from "lodash/toInteger";
-import qs from "query-string";
+import qs, { ParseOptions, StringifyOptions } from "query-string";
 import { useLocation, useHistory } from "react-router-dom";
 
 import { ItemModalEnum } from "@app/constants/route.constants";
 import { getOrderByExtraction } from "@app/helpers/table.helper";
 import { OrderByDef } from "@app/types/table.types";
+
+const ARRAY_FORMAT: StringifyOptions["arrayFormat"] = "bracket";
+const QUERY_OPTIONS: StringifyOptions = {
+  arrayFormat: ARRAY_FORMAT,
+  skipEmptyString: true,
+};
+const PARSE_OPTIONS: ParseOptions = {
+  arrayFormat: ARRAY_FORMAT,
+  parseBooleans: true,
+};
 
 /**
  * The reason for the generic type being wrapped in Partial,
@@ -33,7 +43,8 @@ const useSearchParams = <T = {}>() => {
 
   const getCurrentSearch = useCallback(() => {
     const currentSearch = (qs.parse(
-      location.search
+      location.search,
+      PARSE_OPTIONS
     ) as SearchParamDef) as SearchParamDef<T>;
     currentSearch.orderByExtracted = getOrderByExtraction(
       (currentSearch.orderBy as string) || ""
@@ -70,7 +81,7 @@ const useSearchParams = <T = {}>() => {
     (filters: SearchParamDef<T>) => {
       history.push({
         pathname: location.pathname,
-        search: qs.stringify(filters, { skipEmptyString: true }),
+        search: qs.stringify(filters, QUERY_OPTIONS),
       });
     },
     [history, location.pathname]
@@ -82,7 +93,7 @@ const useSearchParams = <T = {}>() => {
   const updateSearchParams = useCallback(
     (filters: SearchParamDef<T>) => {
       // Keep current search params
-      const currentSearch = qs.parse(location.search);
+      const currentSearch = qs.parse(location.search, PARSE_OPTIONS);
 
       history.push({
         pathname: location.pathname,
@@ -91,7 +102,7 @@ const useSearchParams = <T = {}>() => {
             ...currentSearch,
             ...filters,
           },
-          { skipEmptyString: true }
+          QUERY_OPTIONS
         ),
       });
     },


### PR DESCRIPTION
# Page Filter Updates

## What are you adding?
- Allow Debounced Input value to be updated by parent
- Update Page Filter values to be updated when navigating back and forth in browser history
- Update array format in query-string, so it doesn't show array with one value as a string but actually shows it as an array
- Remove PageFilter custom logic to parseBoolean as it is supported by query-string

## Breaking changes?
- `parseBoolean` is removed from `PageFilter`

## Related PR

