### PR TITLE
Feature: Scroll to top

### DIFF
--- a/src/components/molecules/TableView/TableView.tsx
+++ b/src/components/molecules/TableView/TableView.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from "react-i18next";
 
 import Button from "@app/components/atoms/Button/Button";
 import { getOrderBy } from "@app/helpers/table.helper";
+import { scrollToTop } from "@app/helpers/util.helper";
 import useSearchParams from "@app/hooks/useSearchParams";
 
 import styles from "./TableView.module.scss";
@@ -81,6 +82,9 @@ const TableView = <T extends {}>({
       page,
       pageSize,
     });
+
+    // Scroll to top when there are changes to pagination, sorting, or filters
+    scrollToTop();
 
     onChange?.(pagination, filters, sorter, extra);
   };

--- a/src/components/molecules/TableView/TableView.tsx
+++ b/src/components/molecules/TableView/TableView.tsx
@@ -38,6 +38,7 @@ export interface TableViewProps<T = {}> extends Omit<TableProps<T>, "columns"> {
   onActionMenu?: (key: string, record: T) => void;
   actionWidth?: number | string;
   hideActionColumn?: boolean;
+  disableScrollToTopOnChange?: boolean;
 }
 
 const TableView = <T extends {}>({
@@ -53,6 +54,7 @@ const TableView = <T extends {}>({
   actionWidth = 150,
   hideActionColumn = false,
   className,
+  disableScrollToTopOnChange,
   ...tableProps
 }: TableViewProps<T>) => {
   const { t } = useTranslation();
@@ -83,8 +85,10 @@ const TableView = <T extends {}>({
       pageSize,
     });
 
-    // Scroll to top when there are changes to pagination, sorting, or filters
-    scrollToTop();
+    if (!disableScrollToTopOnChange) {
+      // Scroll to top when there are changes to pagination, sorting, or filters
+      scrollToTop();
+    }
 
     onChange?.(pagination, filters, sorter, extra);
   };

--- a/src/helpers/util.helper.ts
+++ b/src/helpers/util.helper.ts
@@ -28,7 +28,7 @@ export const getInitials = (name: string, maxChar: number) => {
 export const scrollToTop = () => {
   try {
     // trying to use new API - https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo
-    window.scroll({
+    window.scrollTo({
       top: 0,
       left: 0,
       behavior: "smooth",

--- a/src/helpers/util.helper.ts
+++ b/src/helpers/util.helper.ts
@@ -20,3 +20,23 @@ export const getInitials = (name: string, maxChar: number) => {
     .substr(0, maxChar)
     .toUpperCase();
 };
+
+/**
+ * Scroll to top of screen smoothly,
+ * or fallback to instant scroll to top
+ */
+export const scrollToTop = () => {
+  try {
+    // trying to use new API - https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo
+    window.scroll({
+      top: 0,
+      left: 0,
+      behavior: "smooth",
+    });
+  } catch (error) {
+    // fallback for older browsers
+    window.scrollTo(0, 0);
+    document.body.scrollTop = 0; // For Safari
+    document.documentElement.scrollTop = 0;
+  }
+};


### PR DESCRIPTION
# Scroll to top

## What are you adding?
A helper function to scroll to top.
In TableView when pagination, sorting or filter change, then it will scroll to top. 
This improves UX a lot when you have a long list of items and then change pagination in the bottom of the screen, as it before would stay in the bottom of the screen, and you would manually have to scroll to the top of the screen.

A future improvement to this feature, could be to scroll to top of table instead of top of window.

## Breaking changes?
The feature will be enabled by default, so if you want to disable it, then you can use the `disableScrollToTopOnChange`.

## Related PR

