### PR TITLE
migration: Prettier `v2.2.x` to `v2.4.x`

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,11 +1,11 @@
 module.exports = {
-  "trailingComma": "es5",
-  "singleQuote": false,
-  "printWidth": 80,
-  "bracketSpacing": true,
-  "jsxBracketSameLine": false,
-  "tabWidth": 2,
-  "semi": true,
-  "endOfLine": "lf",
-  "arrowParens": "avoid"
+  trailingComma: "es5",
+  singleQuote: false,
+  printWidth: 80,
+  bracketSpacing: true,
+  bracketSameLine: false,
+  tabWidth: 2,
+  semi: true,
+  endOfLine: "lf",
+  arrowParens: "avoid",
 };

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "eslint-plugin-filenames": "^1.3.2",
     "husky": "^7.0.2",
     "lint-staged": "^10.5.4",
-    "prettier": "^2.2.1",
+    "prettier": "^2.4.1",
     "webpack-bundle-analyzer": "^4.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "start": "craco start",
     "build": "craco build",
     "test": "craco test",
-    "format": "prettier 'src/**/*.{ts,tsx,json,scss,css}' --write",
-    "lint": "eslint 'src/**/*.{ts,tsx}' --fix --quiet",
+    "format": "prettier src/**/*.{ts,tsx,json,scss,css} --write",
+    "lint": "eslint src/**/*.{ts,tsx} --fix --quiet",
     "analyze": "ENABLE_ANALYZER=true yarn build",
     "prepare": "husky install"
   },

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "start": "craco start",
     "build": "craco build",
     "test": "craco test",
-    "format": "prettier src/**/*.{ts,tsx,json,scss,css} --write",
-    "lint": "eslint src/**/*.{ts,tsx} --fix --quiet",
+    "format": "prettier 'src/**/*.{ts,tsx,json,scss,css}' --write",
+    "lint": "eslint 'src/**/*.{ts,tsx}' --fix --quiet",
     "analyze": "ENABLE_ANALYZER=true yarn build",
     "prepare": "husky install"
   },

--- a/src/components/atoms/DebouncedInput/DebouncedInput.tsx
+++ b/src/components/atoms/DebouncedInput/DebouncedInput.tsx
@@ -38,13 +38,12 @@ const DebouncedInput = ({
     wait
   );
 
-  const persistedOnChange = (persistOnChange?: React.ChangeEventHandler) => (
-    e: React.ChangeEvent
-  ) => {
-    // persist event as it will be resolved after debounce
-    e.persist();
-    persistOnChange && debouncedOnChange(e, persistOnChange);
-  };
+  const persistedOnChange =
+    (persistOnChange?: React.ChangeEventHandler) => (e: React.ChangeEvent) => {
+      // persist event as it will be resolved after debounce
+      e.persist();
+      persistOnChange && debouncedOnChange(e, persistOnChange);
+    };
 
   return (
     <Input

--- a/src/features/localization/helpers/localization.helpers.ts
+++ b/src/features/localization/helpers/localization.helpers.ts
@@ -6,11 +6,8 @@ export const updateLocalization = async () => {
     return false;
   }
 
-  const {
-    translation,
-    translationMeta,
-    availableLanguages,
-  } = await nstackClient.appOpen();
+  const { translation, translationMeta, availableLanguages } =
+    await nstackClient.appOpen();
 
   if (translation && translationMeta) {
     i18next.addResourceBundle(

--- a/src/hooks/useSearchParams.ts
+++ b/src/hooks/useSearchParams.ts
@@ -42,10 +42,10 @@ const useSearchParams = <T = {}>() => {
   const history = useHistory();
 
   const getCurrentSearch = useCallback(() => {
-    const currentSearch = (qs.parse(
+    const currentSearch = qs.parse(
       location.search,
       PARSE_OPTIONS
-    ) as SearchParamDef) as SearchParamDef<T>;
+    ) as SearchParamDef as SearchParamDef<T>;
     currentSearch.orderByExtracted = getOrderByExtraction(
       (currentSearch.orderBy as string) || ""
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -10505,10 +10505,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
 pretty-bytes@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
# <Feature Title>

## What are you adding?
- upgraded prettier `v2.2.x` to `v2.4.x` 90bd97f
- `jsxBracketSameLine` is deprecated, renamed to [`bracketSameLine`](https://prettier.io/blog/2021/09/09/2.4.0.html#replace-jsxbracketsameline-option-with-bracketsameline-option-11006httpsgithubcomprettierprettierpull11006-by-kurtztechhttpsgithubcomkurtztech) 90bd97f
- fixed no files matching 602758f

## Breaking changes?


## Related PR

