### PR TITLE
No files matching yarn format mac/windows fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "start": "craco start",
     "build": "craco build",
     "test": "craco test",
-    "format": "prettier src/**/*.{ts,tsx,json,scss,css} --write",
-    "lint": "eslint src/**/*.{ts,tsx} --fix --quiet",
+    "format": "prettier \"src/**/*.{ts,tsx,json,scss,css}\" --write",
+    "lint": "eslint \"src/**/*.{ts,tsx}\" --fix --quiet",
     "analyze": "ENABLE_ANALYZER=true yarn build",
     "prepare": "husky install"
   },


### PR DESCRIPTION
fix #119

# <Feature Title>

## What are you adding?
Modified format and lint in package.json so they work in both mac and windows environments