### PR TITLE
fix: delete ‘␍’eslint (prettier / prettier) error appears on Windows …

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
         jsxBracketSameLine: false,
         tabWidth: 2,
         semi: true,
+        endOfLine: "auto",
       },
     ],
     "react/jsx-filename-extension": [

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -6,6 +6,6 @@ module.exports = {
   bracketSameLine: false,
   tabWidth: 2,
   semi: true,
-  endOfLine: "lf",
+  endOfLine: "auto",
   arrowParens: "avoid",
 };


### PR DESCRIPTION
…machine

Github issue: https://github.com/monstar-lab-oss/admin-panel-template-reactjs/issues/124

Applied solution: https://developpaper.com/solution-to-delete-%E2%90%8Deslint-prettier-prettier-error/

# Fix delete ‘␍’eslint (prettier / prettier) error appears on Windows 

## What are you adding?

- Set endOfLine: "auto" on .prettierrc.js and .eslintrc.js


## Breaking changes?


## Related PR

