### PR TITLE
fix: layout remount

### DIFF
--- a/src/features/auth/routes/auth.routes.ts
+++ b/src/features/auth/routes/auth.routes.ts
@@ -1,4 +1,4 @@
-import BlankLayout from "@app/components/layouts/BlankLayout/BlankLayout";
+import { LayoutsEnum } from "@app/routes/constants/route.layouts";
 import { RouteItemDef } from "@app/types/route.types";
 
 import { AuthPathsEnum } from "../constants/auth.paths";
@@ -9,7 +9,7 @@ const LOGIN_SCREEN: RouteItemDef = {
   path: AuthPathsEnum.LOGIN,
   component: LoginScreen,
   navigationTitle: "auth.loginTitle",
-  layout: BlankLayout,
+  layout: LayoutsEnum.BLANK_LAYOUT,
 };
 
 export const AUTH_ROUTES = [LOGIN_SCREEN];

--- a/src/routes/NestedRouteWrapper.tsx
+++ b/src/routes/NestedRouteWrapper.tsx
@@ -4,6 +4,8 @@ import { Permission } from "@app/features/permissions/permissions";
 import RestrictAccess from "@app/routes/components/RestrictAccess/RestrictAccess";
 import { RouteComponentDef, RouteItemDef } from "@app/types/route.types";
 
+import NotFound from "./components/NotFound/NotFound";
+
 interface NestedRouteWrapperProps {
   routesWithComponents: RouteItemDef[];
 }
@@ -33,6 +35,7 @@ const NestedRouteWrapper = ({
           }}
         />
       ))}
+      <Route path="*" render={() => <NotFound />} />
     </Switch>
   );
 };

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -1,9 +1,12 @@
-import { ElementType, memo } from "react";
+import { ElementType, memo, useMemo, useRef } from "react";
 
-import { Switch, Route, Redirect } from "react-router-dom";
+import { Switch, Route, Redirect, useLocation } from "react-router-dom";
 
+import BlankLayout from "@app/components/layouts/BlankLayout/BlankLayout";
 import HeaderLayout from "@app/components/layouts/HeaderLayout/HeaderLayout";
+import SidebarLayout from "@app/components/layouts/SidebarLayout/SidebarLayout";
 import { Permission } from "@app/features/permissions/permissions";
+import { flatten } from "@app/helpers/route.helper";
 import { useAppSelector } from "@app/redux/store";
 import {
   RouteComponentDef,
@@ -14,25 +17,49 @@ import {
 import LoginRedirect from "./components/LoginRedirect/LoginRedirect";
 import NotFound from "./components/NotFound/NotFound";
 import RestrictAccess from "./components/RestrictAccess/RestrictAccess";
+import { LayoutsEnum } from "./constants/route.layouts";
 import { PRIVATE_LIST, PUBLIC_LIST } from "./routes.config";
+
+/**
+ * All Layouts
+ */
+const LAYOUTS = {
+  [LayoutsEnum.HEADER_LAYOUT]: HeaderLayout,
+  [LayoutsEnum.SIDEBAR_LAYOUT]: SidebarLayout,
+  [LayoutsEnum.BLANK_LAYOUT]: BlankLayout,
+};
 
 /**
  * Change the default layout to:
  * - HeaderLayout
  * - SidebarLayout
  */
-const DefaultLayout = HeaderLayout;
+const DefaultLayoutEnum = LayoutsEnum.HEADER_LAYOUT;
 
 const Routes = () => {
   const { isAuthenticated } = useAppSelector(state => ({
     isAuthenticated: state.auth?.isAuthenticated,
   }));
 
+  const location = useLocation();
+  const layoutRef = useRef<ElementType>(LAYOUTS[DefaultLayoutEnum]);
+
+  const matchedRoute: RouteItemDef | undefined = useMemo(
+    () =>
+      flatten([...PUBLIC_LIST, ...PRIVATE_LIST]).filter(
+        route => route.path === location.pathname
+      )[0],
+    [location.pathname]
+  );
+
+  layoutRef.current = isAuthenticated
+    ? LAYOUTS[matchedRoute?.layout ?? DefaultLayoutEnum]
+    : LAYOUTS[LayoutsEnum.BLANK_LAYOUT];
+
   const routeWrapper = (
-    { id, path, layout, component, permissions }: RouteItemDef,
+    { id, path, component, permissions }: RouteItemDef,
     { isProtectedRoute }: RouteWrapperConfigDef | undefined = {}
   ) => {
-    const Layout = (layout ?? DefaultLayout) as ElementType;
     return (
       <Route
         key={id}
@@ -42,11 +69,7 @@ const Routes = () => {
             return <LoginRedirect />;
           }
           const Component = component as RouteComponentDef;
-          const renderContent = (
-            <Layout>
-              <Component {...routeProps} />
-            </Layout>
-          );
+          const renderContent = <Component {...routeProps} />;
 
           return (
             (permissions && (
@@ -64,23 +87,20 @@ const Routes = () => {
     );
   };
 
-  return (
-    <Switch>
-      <Redirect exact from="/" to="/home" />
+  const Layout = layoutRef.current;
 
-      {PRIVATE_LIST.map(route =>
-        routeWrapper(route, { isProtectedRoute: true })
-      )}
-      {PUBLIC_LIST.map(route => routeWrapper(route))}
-      <Route
-        path="*"
-        render={() => (
-          <DefaultLayout>
-            <NotFound />
-          </DefaultLayout>
+  return (
+    <Layout>
+      <Switch>
+        <Redirect exact from="/" to="/home" />
+
+        {PRIVATE_LIST.map(route =>
+          routeWrapper(route, { isProtectedRoute: true })
         )}
-      />
-    </Switch>
+        {PUBLIC_LIST.map(route => routeWrapper(route))}
+        <Route path="*" render={() => <NotFound />} />
+      </Switch>
+    </Layout>
   );
 };
 

--- a/src/routes/constants/route.layouts.ts
+++ b/src/routes/constants/route.layouts.ts
@@ -1,0 +1,5 @@
+export enum LayoutsEnum {
+  SIDEBAR_LAYOUT = "sidebarLayout",
+  HEADER_LAYOUT = "headerLayout",
+  BLANK_LAYOUT = "blankLayout",
+}

--- a/src/types/route.types.ts
+++ b/src/types/route.types.ts
@@ -1,8 +1,9 @@
-import { ComponentType, ReactNode } from "react";
+import { ComponentType } from "react";
 
 import { RouteComponentProps } from "react-router-dom";
 
 import { PermissionEnum } from "@app/features/permissions/permissions";
+import { LayoutsEnum } from "@app/routes/constants/route.layouts";
 
 export type RouteGroupDef = {
   id: string;
@@ -33,7 +34,7 @@ export type RouteItemDef = {
    */
   component: RouteComponentDef;
   /** Layout used for this route */
-  layout?: ReactNode;
+  layout?: LayoutsEnum;
   /** Nested Routes either by array of routes or group of routes */
   nestedRoutes?: Array<RouteItemDef | RouteGroupDef>;
   /** Flag for hide/show in navigation bar */


### PR DESCRIPTION
# Fix layout remounts

## What are you adding?
- Change `layout` type `ReactNode` to `LayoutsEnum` as we ran into compiling error while using the `layout` property inside any `nestedRoutes` property. The reason behind this is I think there is a high chance to use this component (e.g `setting.routes.ts` or `home.routes.ts` with `nestedRoutes` property) inside any layout component before it's going to export. Although it's not that usual to change the layout on nested routes, there is an option to change that if anyone wants to. Just to avoid errors updated this configuration
- Uplift the `Layout` component and determine any layout changes at every route change
- When an unauthenticated user tries some unknown routes, the user is presented with the default 'HeaderLayout'. Fix this as well
- Add `NotFound` component to nested routes

## Breaking changes?


## Related PR

